### PR TITLE
added requirements.txt including test dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+django==2.1.2
+pytest==3.8.2
+pytest-cov==2.6.0
+pytest-django==3.4.3
+pytest-runner==4.2


### PR DESCRIPTION
Installing dependencies using the requirements.txt solved the `pytest` error. I was able to run `pytest` directly after `pip install -r requirements.txt`